### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/devika.py
+++ b/devika.py
@@ -124,7 +124,11 @@ def get_agent_state():
 @route_logger(logger)
 def browser_snapshot():
     snapshot_path = request.args.get("snapshot_path")
-    return send_file(snapshot_path, as_attachment=True)
+    base_path = "/safe/directory/for/snapshots"  # Define your safe base directory here
+    fullpath = os.path.normpath(os.path.join(base_path, snapshot_path))
+    if not fullpath.startswith(base_path):
+        return jsonify({"error": "Invalid snapshot path"}), 400
+    return send_file(fullpath, as_attachment=True)
 
 
 @app.route("/api/get-browser-session", methods=["GET"])


### PR DESCRIPTION
Fixes [https://github.com/PakRTsensen/Controller/security/code-scanning/1](https://github.com/PakRTsensen/Controller/security/code-scanning/1)

To fix the problem, we need to ensure that the `snapshot_path` is validated before it is used in the `send_file` function. The best way to do this is to normalize the path and ensure it is contained within a predefined safe directory. This can be achieved by using `os.path.normpath` and checking that the resulting path starts with the safe directory.

1. Define a safe base directory where snapshots are stored.
2. Normalize the user-provided path and join it with the base directory.
3. Check that the resulting path starts with the base directory.
4. If the path is valid, proceed with `send_file`; otherwise, raise an exception or return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
